### PR TITLE
add type annotation to fix c++ compile error

### DIFF
--- a/src/vm/lua/Lua.hx
+++ b/src/vm/lua/Lua.hx
@@ -51,7 +51,7 @@ class Lua {
 	
 	public function loadLibs(libs:Array<String>) {
 		for(lib in libs) {
-			var openf = 
+			var openf:Dynamic =
 				switch lib {
 					case 'base': luaopen_base;
 					case 'debug': luaopen_debug;


### PR DESCRIPTION
I found that with Haxe 4.3.1 and hxcpp 4.3.2 the C++ compiler was throwing an error because of type agreement on in the C++ generated from this line. I added a type annotation to the Haxe to see if this would fix it, and it did.