### PR TITLE
Don't try to convert VM to a lua value

### DIFF
--- a/src/vm/lua/Lua.hx
+++ b/src/vm/lua/Lua.hx
@@ -125,6 +125,8 @@ class Lua {
 					toLuaValue(l, obj.get(key), cast obj);
 					lua_settable(l, -3);
 				}
+			case TClass(Lua):
+				lua_pushnil(l);
 			case TClass(_):
 				lua_newtable(l);
 				for(key in Type.getInstanceFields(Type.getClass(v))) {


### PR DESCRIPTION
For devious/terrible reasons, I want to put the object that contains a Lua VM object, *into* the Lua VM as a global.

I found that this causes a crash when `toLuaValue()` attempts to convert the `Lua` object. I don't actually need it to do that, and it seems pretty insane to have a VM contain *itself*, so I'm able to avoid this crash by simply putting in `nil` instead of the VM object.

This might be a terrible fix. I really don't know what I'm doing.