### PR TITLE
getGlobalVar return the var as haxe value (rebased)

### DIFF
--- a/src/vm/lua/Lua.hx
+++ b/src/vm/lua/Lua.hx
@@ -87,8 +87,11 @@ class Lua {
 		lua_setglobal(l, name);
 	}
 	
-	public function getGlobalVar(name:String) {
-		return lua_getglobal(l, name);
+	public function getGlobalVar(name:String):Any {
+		lua_getglobal(l, name);
+		var v = toHaxeValue(l, -1);
+		lua_pop(l, -1);
+		return v;
 	}
 	
 	public function destroy() {

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -90,6 +90,14 @@ class RunTests {
 		asserts.assert(compare(Success(1), lua.tryRun('return foo.val()'))); // this make sure this-binding in js is working
 		return asserts.done();
 	}
+
+	public function get() {
+		vm.lua.Lua.badConversionBehavior = Warn;
+		lua.setGlobalVar('foo', new Foo());
+		var foo:{a:Int} = lua.getGlobalVar('foo');
+		asserts.assert(compare(1, foo.a));
+		return asserts.done();
+	}
 	
 	public function func() {
 		function add(a:Int, b:Int) return a + b;
@@ -146,8 +154,8 @@ class RunTests {
 
 @:keep
 class Foo {
-	var a = 1;
-	var b = '2';
+	public var a = 1;
+	public var b = '2';
 	public function new() {}
 	public function add(a:Int, b:Int) return a + b;
 	public function val() return a;


### PR DESCRIPTION
I rebased #8 and made the test work on all targets.

On C++ there's an unfortunate behavior where you can't write

```
var foo:Foo = lua.getGlobalVar("foo");
// foo will be set to null!!
```

That's because Foo is a class, and the anonymous object returned by `toHaxeObj()` is not an instance of the Foo class, even though it implements the same interface (although the functions will be null variables because they don't convert).

So to write the test I've done

```
var foo:{a:Int} = lua.getGlobalVar('foo');
```